### PR TITLE
Potential fix for code scanning alert no. 42: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -48,13 +48,15 @@ public class Servers {
   @ResponseBody
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name: " + column);
+    }
 
     try (var connection = dataSource.getConnection()) {
-      try (var statement =
-          connection.prepareStatement(
-              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+      String query = "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out of order' order by " + column;
+      try (var statement = connection.prepareStatement(query)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/tobbyhans/ucm_WebGoat/security/code-scanning/42](https://github.com/tobbyhans/ucm_WebGoat/security/code-scanning/42)

To fix the problem, we should avoid using string concatenation to build the SQL query. Instead, we should use a prepared statement with a parameterized query. However, since the `column` parameter is used for ordering, which cannot be parameterized directly in SQL, we need to validate the `column` parameter against a whitelist of allowed column names to ensure it is safe to use.

1. Create a whitelist of allowed column names.
2. Validate the `column` parameter against this whitelist.
3. If the `column` parameter is valid, use it in the query; otherwise, throw an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
